### PR TITLE
Prevent Form from being Resized

### DIFF
--- a/app/src/main/java/xterminators/spellingbee/gui/GuiView.java
+++ b/app/src/main/java/xterminators/spellingbee/gui/GuiView.java
@@ -89,6 +89,7 @@ public class GuiView {
         mainFrame.setLocation(centerX, centerY);
         mainFrame.setSize(FRAME_WIDTH, FRAME_HEIGHT);
         mainFrame.setLayout(null);
+        mainFrame.setResizable(false);
         mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         mainFrame.setVisible(true);
     }


### PR DESCRIPTION
Prevents the main form from being resized, so that the user can't resize it and mock the wide gray spaces across most of the screen.