### PR TITLE
fix found words and rank

### DIFF
--- a/app/src/main/java/xterminators/spellingbee/gui/GuiView.java
+++ b/app/src/main/java/xterminators/spellingbee/gui/GuiView.java
@@ -439,11 +439,15 @@ public class GuiView extends View {
 
             if (userChoice == JOptionPane.YES_OPTION) {
                 createRandomPuzzle();
+                drawFoundWords();
+                redrawRank();
                 refocusGuessTextBox();
             }
             // No action on NO_OPTION
         } else {
             createRandomPuzzle();
+            drawFoundWords();
+            redrawRank();
             refocusGuessTextBox();
         }
     }


### PR DESCRIPTION
Found words and rank weren't redrawn when a new random puzzle was generated, so the stuff from the previous puzzle would still be loaded.